### PR TITLE
Entered site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,8 @@ colors:
       color: "#00838f"
     - title: media-color-five
       color: "#00838f"
-description: ""
+description: "The official webpage of the Singapore Social Science Research
+  Council (SSRC). "
 permalink: none
 baseurl: ""
 exclude:

--- a/index.md
+++ b/index.md
@@ -1,7 +1,8 @@
 ---
 layout: homepage
 title: Social Science Research Council
-description: Brief site description here
+description: "The official webpage of the Singapore Social Science Research
+  Council (SSRC). "
 image: /images/logo.svg
 permalink: /
 notification: ""


### PR DESCRIPTION
Entered a site description, so google searches will not indicate 'enter site description here' when we share links on whatsapp or social media. 