### PR TITLE
Wrong URL for Search Engine Optimisation (SEO)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Social Science Research Council
-url: https://www.socialscienceresearchcouncil.edu.sg
+url: https://www.ssrc.edu.sg
 favicon: /images/logo.svg
 colors:
   primary-color: "#005178"

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,3 +1,3 @@
-show_reach: true
+show_reach: false
 social_media: {}
 contact_us: MOE_SSRC_secretariat@moe.gov.sg


### PR DESCRIPTION
Noticed the site description did not update, turns out the URL was 'http://www.socialscienceresearchcouncil.edu.sg' which doesn't exist. Have updated accordingly.

Also disabled REACH, no idea what it is and its not relevant to SSRC. 