### PR TITLE
Removal of GRF 2021 Call ex recipient

### DIFF
--- a/_grant-recipients/Graduate Research Fellows/2021 GRF Fellows.md
+++ b/_grant-recipients/Graduate Research Fellows/2021 GRF Fellows.md
@@ -3,6 +3,7 @@ title: 2021 GRF Fellows
 permalink: /grant-recipients/2021/grf2021/
 description: ""
 third_nav_title: Graduate Research Fellows
+variant: markdown
 ---
 The following recipients were awarded during the inaugural 2021 SSRC GRF call. 
 
@@ -15,9 +16,8 @@ The following recipients were awarded during the inaugural 2021 SSRC GRF call.
 | 5 | NTU | Kunalan Manokara | University of Amsterdam | Bridging the Gap: How Positive Emotions can Promote Intercultural Cooperation | 
 |6| NTU | Charlotte Hand | University of Oxford | Recalibrating Modern Womanhood: Time, Region, and Gender in Nineteenth-Century America| 
 |7| NTU | Guan Xinyu | Cornell University | Heartlanders: Citizenship, Intimacy and Public Housing in Singapore| 
-|8| NTU | Jiemin Looi | University of Texas at Austin | Artificial Intelligence in Advertising: A Mixed-Method Comparison of Human and Virtual Social Media Influencers | 
-|9| NTU | Wan Jian Yong, Darren | Cornell University | Documenting Belonging: Citizenship Claims and Bureaucratic Encounters in British Southeast Asia| 
-|10| NTU | Lydia Cheng Rui Jun | The University of Sydney| A Changing Media Landscape: Exploring the Production and Consumption of Lifestyle Content in Singapore | 
-|11| SMU | Robin Ng Jui Pin | Université Catholique de Louvain | Ratings with Heterogenous Preferences| 
-|12| SMU| Mathew Koo Ming Yew | Yale University | Who Manages the Watchmen? Organisational Structure and Ambition among Coercive Agents| 
-|13| SUTD | Loh Yui Leh Timothy | Massachusetts Institute of Technology | Assistive Technologies for Deaf People in Jordan: Entanglements of Language, Religion, and Disability
+|8| NTU | Wan Jian Yong, Darren | Cornell University | Documenting Belonging: Citizenship Claims and Bureaucratic Encounters in British Southeast Asia| 
+|9| NTU | Lydia Cheng Rui Jun | The University of Sydney| A Changing Media Landscape: Exploring the Production and Consumption of Lifestyle Content in Singapore | 
+|10| SMU | Robin Ng Jui Pin | Université Catholique de Louvain | Ratings with Heterogenous Preferences| 
+|11| SMU| Mathew Koo Ming Yew | Yale University | Who Manages the Watchmen? Organisational Structure and Ambition among Coercive Agents| 
+|12| SUTD | Loh Yui Leh Timothy | Massachusetts Institute of Technology | Assistive Technologies for Deaf People in Jordan: Entanglements of Language, Religion, and Disability

--- a/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
+++ b/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
@@ -5,3 +5,19 @@ variant: markdown
 description: ""
 third_nav_title: Graduate Research Fellows
 ---
+The following recipients were awarded during the 2024 SSRC GRF call.
+
+| S/N | Host Institution | Name of Recipient | Home Institution | Research Project |
+| -------- | -------- | -------- |-------- |-------- |
+| 1 | NUS | Yang Shijian | University of Chicago | Optimal Supply of Public Housing - Evidence from Singapore |
+|2| NUS | Valerie Chuang Zhen Jin | Massachusetts Institute of Technology | Optimal portfolios of investment, insurance, and aid: theory and evidence from flood interventions |
+|3| NUS | Choo Ruizhi | College of Arts, Language, and Letters, University of Hawaii at Manoa | Of Ikan & Imperialism: A Marine Environment History of British Malaya |
+|4| NUS | Hoong Juan Ru | Business Economics, Harvard Business School | Coarsening AI Signals to Enhance Human Decision-Making |
+|5| NUS | Chiang Cheng Chai | University of California, Berkeley | The Theatre and Its Dubber: Queer Translation in the Anglo-Chinese Diaspora |
+|6| NTU | Loh Yui Leh Timothy | Princeton University | Formations of Deafness across Singapore and Jordan |
+|7| NTU | Charles Joseph L. Alba | Washington University in St Louis | Practical use of large language models towards government-assistance schemes: A CDC voucher case study |
+|8| NTU | Lu Si Yinn | University of Toronto | Unpacking Loneliness in Later Life: A Critical Ethnographic Inquiry of Older Adults' Experiences and Practices in Singapore |
+|9| NTU | Tan Wenqi | The University of Sydney | Changing the shape of the (virtual) world: Disability inclusion in social virtual reality |
+|10| SMU | Tiffany Lau | London School of Economics | Understanding the Impact of China's Influence in Singapore and Malaysia |
+|11| SMU | Subadevan Boyd-Devan | Brown University | Urban Kaleidoscope: Radicalized Space and South Asian Migrant Inclusion/Exclusion in Global City Singapore |
+|12| SMU | Robert William Straughan | The University of British Columbia | Identity Politics and Immigration: Understanding the Implications of National Identity Priming for Immigration Attitudes in Asian and Western Contexts |

--- a/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
+++ b/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
@@ -1,7 +1,0 @@
----
-title: 2024 GRF Fellows
-permalink: /2024-grf-fellows/
-variant: tiptap
-description: ""
-third_nav_title: Graduate Research Fellows
----

--- a/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
+++ b/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
@@ -1,0 +1,7 @@
+---
+title: 2024 GRF Fellows
+permalink: /2024-grf-fellows/
+variant: tiptap
+description: ""
+third_nav_title: Graduate Research Fellows
+---

--- a/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
+++ b/_grant-recipients/Graduate Research Fellows/2024 GRF Fellows.md
@@ -1,0 +1,7 @@
+---
+title: 2024 GRF Fellows
+permalink: /grant-recipients/2024/grf2024/
+variant: markdown
+description: ""
+third_nav_title: Graduate Research Fellows
+---

--- a/_grant-recipients/collection.yml
+++ b/_grant-recipients/collection.yml
@@ -18,6 +18,7 @@ collections:
       - SSHR Fellows/2020 Fellows.md
       - SSHR Fellows/2019 Fellows.md
       - SSHR Fellows/2018 Fellows.md
+      - Graduate Research Fellows/2024 GRF Fellows.md
       - Graduate Research Fellows/2023 GRF Fellows.md
       - Graduate Research Fellows/.keep
       - Graduate Research Fellows/2022 GRF Fellows.md


### PR DESCRIPTION
Removed Jiemin Looi, from the list of recipients for the GRF 2021 call as her project was terminated after she took up the position of Assistant Professor at Hong Kong University, please.